### PR TITLE
update about pem file for option -k

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ projects:
 
 Then run the server manually
 
+```convert id_rsa to pem
+openssl rsa -in ~/.ssh/id_rsa -outform pem > id_rsa.pem
+```
+
 ```shell
-go run goship.go -b localhost:8888 -k ~/.ssh/id_rsa
+go run goship.go -b localhost:8888 -k ~/.ssh/id_rsa.pem
 ```
 
 Available command line flags for the `go run goship.go` command are:


### PR DESCRIPTION
I wrote how to convert rsa file to pem format.
Because when I try to use id_rsa file which made by ssh-keygen command, goship.go output below error.

```
 Error: asn1: structure error: length too large
```
