### PR TITLE
Fix pivotal commenting and timestamps

### DIFF
--- a/goship.go
+++ b/goship.go
@@ -804,7 +804,7 @@ func PostPivotalComment(id string, m string, piv *PivotalConfiguration) (err err
 		return err
 	}
 	req.URL.RawQuery = p.Encode()
-	req.Header.Add("Content-Typen", "application/json")
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-TrackerToken", piv.token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Fixed Pivotal Comment timestamps to load JST, falling back to UTC on error. Fixed Pivotal Story detection to compare `current_hash...latest_hash` instead of `latest_hash...current_hash` which was causing the function to return zero commits.
