### PR TITLE
[#92191452] add project name to confirm dialog message

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -76,7 +76,8 @@
   {{ if .ConfirmDeployFlag }}
   $('form.form-deploy').submit(function(e){
       var env = $(this).parents('tr.environment').data('id');
-      return confirm('Are you sure you wish to deploy to ' + env + '?');
+      var project = $(this).find('input[name="project"]').val();
+      return confirm('Are you sure you wish to deploy ' + project + ' to ' + env + '?');
   });
   {{ end }}
 


### PR DESCRIPTION
This PR is a simple update to add the **project name** to the confirmation dialog for better clarity:

![screen shot 2015-04-21 at 6 26 00 pm](https://cloud.githubusercontent.com/assets/2164346/7249232/ec71fd9a-e853-11e4-8988-21bbbcb55fa4.png)
