### PR TITLE
shift plugin columns left so deployed versions show up besides deploy button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,11 +11,11 @@
               <tr>
                 <th class="column-environment">Environment</th>
                 <th class="column-hosts">Hosts</th>
-                <th class="column-deployed-revision">Deployed Revision</th>
                 {{/* add and display the header of all plugins' columns */}}
                 {{range $project.PluginColumns}}
                   {{.RenderHeader}}
                 {{end}}
+                <th class="column-deployed-revision">Deployed Revision</th>
                 <th class="column-deploy"></th>
                 <th class="column-comment">  </th>
               </tr>
@@ -29,13 +29,13 @@
                     <div>{{$host.URI}}</div>
                   {{end}}
                 </td>
-                <td class="hosts">
-                  Loading...
-                </td>
                 {{/* add and display the main content (through Render) of all plugins' columns */}}
                 {{range $project.PluginColumns}}
                   {{.RenderDetail}}
                 {{end}}
+                <td class="hosts">
+                  Loading...
+                </td>
                 <td>
                   <form class="form-deploy hidden" method="POST" action="/deploy" target="_blank" style="margin-bottom: 0">
                     <input type="hidden" name="environment" value="{{$environment.Name}}"/>


### PR DESCRIPTION
This PR updates the plugin columns in the home page leftwards by 1 column space so that the `deployed revisions` column is next to the deploy button.

screenshot below:

![screen shot 2015-04-24 at 3 14 05 pm](https://cloud.githubusercontent.com/assets/2164346/7313469/9bc132f6-ea94-11e4-8828-5065d76e1eec.png)
