### PR TITLE
[update] add min width for travis plugin

### DIFF
--- a/plugins/travis/travis.go
+++ b/plugins/travis/travis.go
@@ -30,7 +30,7 @@ type TravisColumn struct {
 }
 
 func (c TravisColumn) RenderHeader() (template.HTML, error) {
-	return template.HTML("<th>Build Status</th>"), nil
+	return template.HTML(`<th style="min-width: 100px">Build Status</th>`), nil
 }
 
 func (c TravisColumn) RenderDetail() (template.HTML, error) {

--- a/plugins/travis/travis_test.go
+++ b/plugins/travis/travis_test.go
@@ -68,7 +68,7 @@ func TestRenderHeader(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	want := template.HTML("<th>Build Status</th>")
+	want := template.HTML(`<th style="min-width: 100px">Build Status</th>`)
 	if want != got {
 		t.Errorf("Want %#v, got %#v", want, got)
 	}


### PR DESCRIPTION
This PR updates the Travis plugin by defining a minimum width for the the Travis plugin column. This ensures that the `Build Status` wording.


current issue:

when project has no travis build, the `Build Status` header *breaks* on default.
![travis](https://cloud.githubusercontent.com/assets/2164346/7383863/0d528ed0-ee62-11e4-911b-6cbb6016babf.png)
