### PR TITLE
[#92205364] pivotal plugin frontend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ go:
   - 1.4
 
 script:
-  - go build -a
   - go test ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ go:
   - 1.4
 
 script:
+  - go build -a
   - go test ./...

--- a/goship.go
+++ b/goship.go
@@ -742,7 +742,7 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	js, css := getAssetsTemplates()
-	t.ExecuteTemplate(w, "base", map[string]interface{}{"Javascript": js, "Stylesheet": css, "Projects": c.Projects, "User": u, "Page": "home", "ConfirmDeployFlag": *confirmDeployFlag, "GithubToken": os.Getenv(gitHubAPITokenEnvVar), "PivotalToken": c.Pivotal.Token})
+	t.ExecuteTemplate(w, "base", map[string]interface{}{"Javascript": js, "Stylesheet": css, "Projects": c.Projects, "User": u, "Page": "home", "ConfirmDeployFlag": *confirmDeployFlag})
 }
 
 func getAssetsTemplates() (js, css template.HTML) {

--- a/goship.go
+++ b/goship.go
@@ -742,7 +742,7 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	js, css := getAssetsTemplates()
-	t.ExecuteTemplate(w, "base", map[string]interface{}{"Javascript": js, "Stylesheet": css, "Projects": c.Projects, "User": u, "Page": "home", "ConfirmDeployFlag": *confirmDeployFlag})
+	t.ExecuteTemplate(w, "base", map[string]interface{}{"Javascript": js, "Stylesheet": css, "Projects": c.Projects, "User": u, "Page": "home", "ConfirmDeployFlag": *confirmDeployFlag, "GithubToken": os.Getenv(gitHubAPITokenEnvVar), "PivotalToken": c.Pivotal.Token})
 }
 
 func getAssetsTemplates() (js, css template.HTML) {

--- a/goship.go
+++ b/goship.go
@@ -742,7 +742,10 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	js, css := getAssetsTemplates()
-	t.ExecuteTemplate(w, "base", map[string]interface{}{"Javascript": js, "Stylesheet": css, "Projects": c.Projects, "User": u, "Page": "home", "ConfirmDeployFlag": *confirmDeployFlag})
+	gt := os.Getenv(gitHubAPITokenEnvVar)
+	pt := c.Pivotal.Token
+
+	t.ExecuteTemplate(w, "base", map[string]interface{}{"Javascript": js, "Stylesheet": css, "Projects": c.Projects, "User": u, "Page": "home", "ConfirmDeployFlag": *confirmDeployFlag, "GithubToken": gt, "PivotalToken": pt})
 }
 
 func getAssetsTemplates() (js, css template.HTML) {

--- a/goship_test.go
+++ b/goship_test.go
@@ -248,29 +248,6 @@ func TestProjectFromName(t *testing.T) {
 	}
 }
 
-func TestCleanProjects(t *testing.T) {
-	authentication.authorization = true
-	req, _ := http.NewRequest("GET", "", nil)
-	w := httptest.NewRecorder()
-	HomeHandler(w, req)
-
-	p, err := goship.ParseETCD(&MockEtcdClient{})
-	if err != nil {
-		t.Fatalf("Can't parse %s %s", t, err)
-	}
-	u := User{}
-	u.UserName = "bob"
-
-	got := len(p.Projects)
-	if got < 1 {
-		t.Errorf("clean projects test expects projects to have at least one project [%d]", got)
-	}
-	got = len(removeUnauthorizedProjects(p.Projects, req, u))
-	if got != 0 {
-		t.Errorf("clean projects failed to clean project for unauth user.. [%d]", got)
-	}
-}
-
 func TestGetUser(t *testing.T) {
 	authentication.authorization = true
 	req, _ := http.NewRequest("GET", "", nil)

--- a/goship_test.go
+++ b/goship_test.go
@@ -248,6 +248,29 @@ func TestProjectFromName(t *testing.T) {
 	}
 }
 
+func TestCleanProjects(t *testing.T) {
+	authentication.authorization = true
+	req, _ := http.NewRequest("GET", "", nil)
+	w := httptest.NewRecorder()
+	HomeHandler(w, req)
+
+	p, err := goship.ParseETCD(&MockEtcdClient{})
+	if err != nil {
+		t.Fatalf("Can't parse %s %s", t, err)
+	}
+	u := User{}
+	u.UserName = "bob"
+
+	got := len(p.Projects)
+	if got < 1 {
+		t.Errorf("clean projects test expects projects to have at least one project [%d]", got)
+	}
+	got = len(removeUnauthorizedProjects(p.Projects, req, u))
+	if got != 0 {
+		t.Errorf("clean projects failed to clean project for unauth user.. [%d]", got)
+	}
+}
+
 func TestGetUser(t *testing.T) {
 	authentication.authorization = true
 	req, _ := http.NewRequest("GET", "", nil)

--- a/goship_test.go
+++ b/goship_test.go
@@ -251,8 +251,6 @@ func TestProjectFromName(t *testing.T) {
 func TestCleanProjects(t *testing.T) {
 	authentication.authorization = true
 	req, _ := http.NewRequest("GET", "", nil)
-	w := httptest.NewRecorder()
-	HomeHandler(w, req)
 
 	p, err := goship.ParseETCD(&MockEtcdClient{})
 	if err != nil {
@@ -275,7 +273,7 @@ func TestGetUser(t *testing.T) {
 	authentication.authorization = true
 	req, _ := http.NewRequest("GET", "", nil)
 	w := httptest.NewRecorder()
-	HomeHandler(w, req)
+
 	session, err := store.Get(req, sessionName)
 	if err != nil {
 		t.Errorf("Can't get a session store")

--- a/helpers/staticfiles_test.go
+++ b/helpers/staticfiles_test.go
@@ -12,7 +12,7 @@ var getFilePathsTests = []struct {
 	expected    []string
 	expectErr   error
 }{
-	{"../static/js", ".js", []string{}, nil},
+	{"../static/js", ".js", []string{"pivotal.js"}, nil},
 	{"../static/js", ".gitkeep", []string{".gitkeep"}, nil},
 	{"../static/css", ".css", []string{"styles.css"}, nil},
 }
@@ -68,7 +68,7 @@ var javascriptTemplateTests = []struct {
 	expected    string
 	expectErr   error
 }{
-	{"../static/js", "", nil},
+	{"../static/js", "<script src='/static/js/pivotal.js'></script>", nil},
 	{"../static/css", "", nil},
 }
 

--- a/lib/goship.go
+++ b/lib/goship.go
@@ -55,7 +55,7 @@ type Column interface {
 	// RenderHeader() returns a HTML template that should render a <th> element
 	RenderHeader() (template.HTML, error)
 	// RenderDetail() returns a HTML template that should render a <td> element
-	RenderDetail(Environment) (template.HTML, error)
+	RenderDetail() (template.HTML, error)
 }
 
 // Project stores information about a GitHub project, such as its GitHub URL and repo name, and a list of extra columns (PluginColumns)

--- a/plugins/helloworld/helloworld.go
+++ b/plugins/helloworld/helloworld.go
@@ -22,7 +22,7 @@ func (c HelloWorldColumn) RenderHeader() (template.HTML, error) {
 	return template.HTML("<th>Example Column</th>"), nil
 }
 
-func (c HelloWorldColumn) RenderDetail(e goship.Environment) (template.HTML, error) {
+func (c HelloWorldColumn) RenderDetail() (template.HTML, error) {
 	return template.HTML("<td>Hello World!</td>"), nil
 }
 

--- a/plugins/pivotal/pivotal.go
+++ b/plugins/pivotal/pivotal.go
@@ -1,37 +1,14 @@
 package pivotal
 
 import (
-	"encoding/json"
-	"fmt"
 	"html/template"
-	"log"
-	"net/http"
 
 	goship "github.com/gengo/goship/lib"
 	"github.com/gengo/goship/plugins/plugin"
 )
 
-var BootstrapLabel = map[string]string{
-	"_base":     "<span class=\"label label-%s\">%s</span>",
-	"planned":   "default", // unstarted is `planned` in API response
-	"started":   "info",
-	"finished":  "primary",
-	"delivered": "warning",
-	"accepted":  "success",
-	"rejected":  "danger",
-}
-
-var GetPivotalIDFromGithubCommits = goship.GetPivotalIDFromCommits
-
-const (
-	pivotalURL      = "https://www.pivotaltracker.com"
-	pivotalAPIURL   = pivotalURL + "/services/v5"
-	pivotalStoryURL = pivotalURL + "/story/show"
-)
-
 type PivotalPlugin struct {
 	Column StoryColumn
-	Client PivotalClientInterface
 }
 
 func init() {
@@ -39,87 +16,19 @@ func init() {
 	plugin.RegisterPlugin(p)
 }
 
-type PivotalClientInterface interface {
-	GetStoryStatus(chan<- string, string)
-}
-
-type PivotalClient struct {
-	Token string
-}
-
-func (pc PivotalClient) GetStoryStatus(ch chan<- string, pivotalID string) {
-	pivotalStoryAPIURL := pivotalAPIURL + "/stories/%s"
-	url := fmt.Sprintf(pivotalStoryAPIURL, pivotalID)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		log.Printf("error setting up http request. err: %s", err)
-		ch <- ""
-	}
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-TrackerToken", pc.Token)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		log.Printf("error making http request. err: %s", err)
-		ch <- ""
-	}
-	defer resp.Body.Close()
-	var psr = new(PivotalStoryResponse)
-	json.NewDecoder(resp.Body).Decode(&psr)
-	ch <- psr.Status
-}
-
-type StoryColumn struct {
-	Project       goship.Project
-	PivotalClient PivotalClientInterface
-}
-
-// partial representation of the full json response from Pivotal
-type PivotalStoryResponse struct {
-	Status string `json:"current_state"`
-}
+type StoryColumn struct{}
 
 func (c StoryColumn) RenderHeader() (template.HTML, error) {
-	return template.HTML("<th style=\"min-width: 200px;\">Stories</th>"), nil
+	return template.HTML(`<th style="min-width: 200px;">Stories</th>`), nil
 }
 
-func (c StoryColumn) RenderDetail(e goship.Environment) (template.HTML, error) {
-	var content = ""
-	var infoTmpl = "<a href=\"%s/%s\" target=\"_blank\">%s</a> %s<br/>"
-	var owner = c.Project.RepoOwner
-	var repo = c.Project.RepoName
-	var latestCommit = e.LatestGitHubCommit
-	var currentCommit string
-	for _, host := range e.Hosts {
-		if host.GitHubDiffURL != "" {
-			currentCommit = host.LatestCommit
-			break
-		}
-	}
-
-	pivotalIDs, err := GetPivotalIDFromGithubCommits(owner, repo, latestCommit, currentCommit)
-	//pivotalIDs, err := GetPivotalIDFromGithubCommits(owner, repo, "095168b87e702173ba7265e4287f4f8f96f1bb18", "4833a8a4e41b39099c5c7e08f78046bd842de5e7")
-	if err != nil {
-		log.Printf("Failed to obtain pivotal IDs from Github commits. err: %s", err)
-		return template.HTML("<td></td>"), nil
-	}
-	for _, id := range pivotalIDs {
-		ch := make(chan string)
-		go c.PivotalClient.GetStoryStatus(ch, id)
-		status := <-ch
-		label := fmt.Sprintf(BootstrapLabel["_base"], BootstrapLabel[status], status) // make bootstrap label based on status
-		info := fmt.Sprintf(infoTmpl, pivotalStoryURL, id, id, label)
-		content += info // add ticket info into content template
-	}
-	return template.HTML(fmt.Sprintf("<td>%s</td>", content)), nil
+func (c StoryColumn) RenderDetail() (template.HTML, error) {
+	return template.HTML(`<td class="story"></td>`), nil
 }
 
 func (p *PivotalPlugin) Apply(g goship.Config) error {
-	p.Client = PivotalClient{Token: g.Pivotal.Token}
 	for i := range g.Projects {
-		g.Projects[i].AddPluginColumn(StoryColumn{
-			Project:       g.Projects[i],
-			PivotalClient: p.Client,
-		})
+		g.Projects[i].AddPluginColumn(StoryColumn{})
 	}
 	return nil
 }

--- a/plugins/pivotal/pivotal_test.go
+++ b/plugins/pivotal/pivotal_test.go
@@ -1,69 +1,31 @@
 package pivotal
 
 import (
-	"fmt"
 	"html/template"
 	"testing"
 
 	goship "github.com/gengo/goship/lib"
 )
 
-var mockProject = goship.Project{
-	PluginColumns: nil,
-	Name:          "myapp",
-	GitHubURL:     "http://github.com/mycompany/myapp",
-	RepoName:      "myapp",
-	RepoOwner:     "mycompany",
-	Environments: []goship.Environment{
-		goship.Environment{LatestGitHubCommit: "abc123", Hosts: []goship.Host{{LatestCommit: "abc456"}}},
-	},
-}
-
-type MockPivotalClient struct{}
-
-func (pc MockPivotalClient) GetStoryStatus(ch chan<- string, pivotalID string) {
-	ch <- "delivered"
-}
-
 func TestRenderDetail(t *testing.T) {
-	c := StoryColumn{
-		Project:       mockProject,
-		PivotalClient: MockPivotalClient{},
-	}
-	// patch
-	var mockIDs = []string{"1234", "2345", "3456"}
-	// patching the response from goship.GetPivotalIDFromCommits
-	GetPivotalIDFromGithubCommits = func(_, _, _, _ string) ([]string, error) {
-		return mockIDs, nil
-	}
-	e := goship.Environment{}
-	got, err := c.RenderDetail(e)
+	c := StoryColumn{}
+	got, err := c.RenderDetail()
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	var content = ""
-	for _, id := range mockIDs {
-		var infoTmpl = "<a href=\"%s/%s\" target=\"_blank\">%s</a> %s<br/>"
-		label := fmt.Sprintf(BootstrapLabel["_base"], BootstrapLabel["delivered"], "delivered")
-		info := fmt.Sprintf(infoTmpl, pivotalStoryURL, id, id, label)
-		content += info
-	}
-	want := template.HTML(fmt.Sprintf("<td>%s</td>", content))
+	want := template.HTML(`<td class="story"></td>`)
 	if want != got {
 		t.Errorf("Want %#v, got %#v", want, got)
 	}
 }
 
 func TestRenderHeader(t *testing.T) {
-	c := StoryColumn{
-		Project:       mockProject,
-		PivotalClient: nil,
-	}
+	c := StoryColumn{}
 	got, err := c.RenderHeader()
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	want := template.HTML("<th style=\"min-width: 200px;\">Stories</th>")
+	want := template.HTML(`<th style="min-width: 200px;">Stories</th>`)
 	if want != got {
 		t.Errorf("Want %#v, got %#v", want, got)
 	}

--- a/plugins/travis/travis.go
+++ b/plugins/travis/travis.go
@@ -33,7 +33,7 @@ func (c TravisColumn) RenderHeader() (template.HTML, error) {
 	return template.HTML(`<th style="min-width: 100px">Build Status</th>`), nil
 }
 
-func (c TravisColumn) RenderDetail(e goship.Environment) (template.HTML, error) {
+func (c TravisColumn) RenderDetail() (template.HTML, error) {
 	var url, svg string
 	if c.Token == "" {
 		url = fmt.Sprintf("%s/%s/%s", rootUrls[0], c.Organization, c.Project)

--- a/plugins/travis/travis_test.go
+++ b/plugins/travis/travis_test.go
@@ -80,8 +80,7 @@ func TestRenderDetailPublic(t *testing.T) {
 		Token:        "",
 		Organization: "test",
 	}
-	e := goship.Environment{}
-	got, err := c.RenderDetail(e)
+	got, err := c.RenderDetail()
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -97,8 +96,7 @@ func TestRenderDetailPrivate(t *testing.T) {
 		Token:        "test_token",
 		Organization: "test",
 	}
-	e := goship.Environment{}
-	got, err := c.RenderDetail(e)
+	got, err := c.RenderDetail()
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -52,7 +52,6 @@
               projectDiffs[project] = url;
           }
       });
-
       return projectDiffs;
   }
 
@@ -76,7 +75,6 @@
 
   function getGithubPivotalIDs(github_token, repo, sha1, sha2, callback){
     var compare_uri = 'https://api.github.com/repos/gengo/'+ repo + '/compare/' + sha1 + '...' + sha2;
-
     $.ajax({
       url: compare_uri,
       type: 'GET',
@@ -127,9 +125,8 @@
   }
 
   var diffs = getProjectDiffs();
-  setTimeout(function(){ diffs = getProjectDiffs(); }, 1000);
+  setTimeout(function(){ diffs = getProjectDiffs(); }, 1000);  // fetch diffs again after 1 sec
   $(document).ready(function(){
-    // grab all diff URLs onto a map
 
     // add button to story columns
     var button = '<button class="btn btn-default getStories">get stories</button>';

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -1,0 +1,183 @@
+(function($){
+  var config = {
+    selectors: { // according to query selector standards
+      project: '.project',
+      project_id: 'data-id',
+      environment: '.environment',
+      story_column: '.story',
+      github_link: '.GitHubDiffURL',
+    },
+    pivotal: {
+      label: '<span class="label label-unknown">status</span>',
+      ticket_id_regexp: /\[#(\d+)\]/
+    },
+    github: {
+      url_compare_reg_exp: /.*\/(.*)\/compare/
+    },
+    urls: {
+      pivotal: {
+        base: "https://www.pivotaltracker.com",
+        story: '/story/show',
+        api: '/services/v5',
+      }
+    }
+  };
+
+  function mapStatusLabelClass(status) {
+    // returns label class type (as of Twitter Bootstrap 3)
+    switch(status) {
+      case 'rejected':
+        return 'danger';
+      case 'accepted':
+        return 'success';
+      case 'delivered':
+        return 'warning';
+      case 'finished':
+        return 'primary';
+      case 'started':
+        return 'info';
+      default:
+        return 'default';
+    }
+  }
+
+  function getProjectDiffs(){
+
+      var projectDiffs = [];
+
+      $(config.selectors.project).each(function() {
+          var project = $(this).attr(config.selectors.project_id);
+          var url = $(this).find(config.selectors.github_link).attr('href');
+          if (url && url != "undefined"){
+              projectDiffs[project] = url;
+          }
+      });
+
+      return projectDiffs;
+  }
+
+  function getLinkDiv(pt_info) {
+    var links = '',
+        info,
+        statusLabel;
+    for(f in pt_info)
+    {
+      info = pt_info[f];
+      statusLabel = config.pivotal.label.replace('unknown' , mapStatusLabelClass(info['status'])).replace('status', info['status']);
+      links += '<a href="' + info['url'] + '" target="_blank">#' + info['id'] + ' ' + statusLabel +'</a><br/>';                 
+    }
+    return links;
+  }
+
+  function injectPivotalStatus(project_id, pt_info) {
+      var project_selector = config.selectors.project + '[' + config.selectors.project_id + '="' + project_id + '"]';
+      $(project_selector).find(config.selectors.story_column).append(getLinkDiv(pt_info));
+  }
+
+  function getGithubPivotalIDs(github_token, repo, sha1, sha2, callback){
+    var compare_uri = 'https://api.github.com/repos/gengo/'+ repo + '/compare/' + sha1 + '...' + sha2;
+
+    $.ajax({
+      url: compare_uri,
+      type: 'GET',
+      beforeSend: function(xhr) { 
+        xhr.setRequestHeader("Authorization", "token " + github_token);
+      },
+      success: function (data) {
+        callback(data.commits);            
+      },
+      error: function (data) {
+        console.log(data);
+      }
+    });
+  }
+
+  function getCommitIDs(msgs){
+    // create an object with no prior properties; therefore, all keys in set are the values we want
+    pivotal_ids = Object.create(null);
+    for(msg in msgs)
+    {
+      var message = msgs[msg];
+      var matches = message.match(config.pivotal.ticket_id_regexp)
+      if(!matches) return;
+      var id = matches[1];
+      if(id && !(id in pivotal_ids)) pivotal_ids[id] = true;
+    }
+    return Object.keys(pivotal_ids); // returning just the keys gives us all unique pivotal IDs
+  }
+
+  function getPivotalInfo(pt_token, story_id, callback){
+    var story_uri = config.urls.pivotal.base + config.urls.pivotal.api + '/stories/' + story_id;
+    $.ajax({
+      type:"GET",
+      beforeSend: function (request)
+      {
+        request.setRequestHeader("X-TrackerToken", pt_token);
+      },
+      url: story_uri,
+      success: function (data) {
+        var info = {
+          'id': story_id
+        };
+        info['status'] = data['current_state'];
+        info['url'] = data['url'];
+        callback(info);
+      }
+    });
+  }
+
+  var diffs = getProjectDiffs();
+  setTimeout(function(){ diffs = getProjectDiffs(); }, 1000);
+  $(document).ready(function(){
+    // grab all diff URLs onto a map
+
+    // add button to story columns
+    var button = '<button class="btn btn-default getStories">get stories</button>';
+    $(config.selectors.story_column).each(function(){
+      $(this).html(button);
+    });
+
+    // "get stories" button onClick handler
+    $('.getStories').click(function(e){
+      e.preventDefault();
+      var project = $(this).parents(config.selectors.project).data('id');
+      if(project in diffs) {
+        // great! we found diffs for this project; load the pivotal stories
+        $(this).hide(); // do not show button
+        (function(project) {
+        var url = diffs[project];
+        // hashes: currentCommit...latestCommit
+        var hashes = (url.substr(url.lastIndexOf('/') + 1)).split('...');
+        var proj_name = url.match(config.github.url_compare_reg_exp)[1];
+
+        getGithubPivotalIDs(GITHUB_TOKEN, proj_name, hashes[0], hashes[1], function(commits){
+          var messages = [];
+          for(commit in commits) {
+            messages.push(commits[commit]['commit']['message']); // get all github commit messages
+          }
+
+          var pivotal_ids = getCommitIDs(messages); // extract pivotal ticket IDs
+          if(!pivotal_ids) {
+            alert('No associated Pivotal stories found in commit messages.');
+            $(this).show();
+            return
+          };
+
+          var display_message = [];
+          for(pt_id in pivotal_ids)
+          {
+            var id = pivotal_ids[pt_id];
+            getPivotalInfo(PIVOTAL_TOKEN, id, function(info){
+              display_message[id] = info;
+              injectPivotalStatus(project, display_message);
+            });
+          }
+        });
+      })(project);
+      }
+      else {
+        alert('There seems to be no diffs for ' + project + '. Goship may still be loading the diff, if any. Please try again later.');
+      }
+    });
+  });
+}(jQuery));

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
                 </td>
                 {{/* add and display the main content (through Render) of all plugins' columns */}}
                 {{range $project.PluginColumns}}
-                  {{.RenderDetail $environment}}
+                  {{.RenderDetail}}
                 {{end}}
                 <td class="hosts">
                   Loading...

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,8 +67,8 @@
   <div class="hidden" id="host-skeleton"><a class="GitHubCommitURL" href=""></a> <span class="hidden"> (<a class="GitHubDiffURL" href="">diff</a>)</span></div>
 
   <script type="text/javascript">
-  GITHUB_TOKEN = "";
-  PIVOTAL_TOKEN = "";
+  GITHUB_TOKEN = "{{.GithubToken}}";
+  PIVOTAL_TOKEN = "{{.PivotalToken}}";
   $(function(){
     $('[data-toggle="tooltip"]').tooltip();
     // make ajax queries for each project

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,6 +67,8 @@
   <div class="hidden" id="host-skeleton"><a class="GitHubCommitURL" href=""></a> <span class="hidden"> (<a class="GitHubDiffURL" href="">diff</a>)</span></div>
 
   <script type="text/javascript">
+  GITHUB_TOKEN = "{{.GithubToken}}";
+  PIVOTAL_TOKEN = "{{.PivotalToken}}";
   $(function(){
     $('[data-toggle="tooltip"]').tooltip();
     // make ajax queries for each project

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,8 +67,8 @@
   <div class="hidden" id="host-skeleton"><a class="GitHubCommitURL" href=""></a> <span class="hidden"> (<a class="GitHubDiffURL" href="">diff</a>)</span></div>
 
   <script type="text/javascript">
-  GITHUB_TOKEN = "{{.GithubToken}}";
-  PIVOTAL_TOKEN = "{{.PivotalToken}}";
+  GITHUB_TOKEN = "";
+  PIVOTAL_TOKEN = "";
   $(function(){
     $('[data-toggle="tooltip"]').tooltip();
     // make ajax queries for each project


### PR DESCRIPTION
original story:

This PR updates Goship such that the Pivotal story plugin's logic is rendered on the frontend (javascript) instead (so that Pivotal stories are loaded only on demand; see screenshots below)

The main javascript code has been a port of an existing Chrome extension by @slamice, and this PR adapts it such that:

- we do not load all Pivotal stories and their statuses all at once; instead, Goship user presses the `Get Stories` button and the Pivotal stories are loaded

- alerts are shown if no associated stories found in Github commit messages, or if the Goship server may still be loading diffs.

-----

##### screenshots

![screen shot 2015-05-14 at 10 38 11 am](https://cloud.githubusercontent.com/assets/2164346/7625265/30cdf2da-fa30-11e4-99bd-4ff1cc1157a8.png)

![screen shot 2015-05-14 at 10 38 19 am](https://cloud.githubusercontent.com/assets/2164346/7625259/25321258-fa30-11e4-93fe-913786864447.png)

![screen shot 2015-05-14 at 11 57 48 am](https://cloud.githubusercontent.com/assets/2164346/7625287/7b722f18-fa30-11e4-8200-5acbe5296777.png)
