### PR TITLE
[#92205364] small UI improvements for Pivotal plugin

### DIFF
--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -6,7 +6,6 @@
       environment: '.environment',
       story_column: '.story',
       github_link: '.GitHubDiffURL',
-      host_column: '.hosts',
       refresh_button: '.refresh',
     },
     pivotal: {
@@ -145,7 +144,6 @@
 
     // set up listeners on Refresh Button
     $(config.selectors.refresh_button).click(function(){
-      var diff_load_status = $(this).parents(config.selectors.project).find(config.selectors.host_column).text();
       $(this).parents(config.selectors.project).find(config.selectors.story_column).html();
       $(this).parents(config.selectors.project).find(config.selectors.story_column).html(button);
       }

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -6,6 +6,8 @@
       environment: '.environment',
       story_column: '.story',
       github_link: '.GitHubDiffURL',
+      host_column: '.hosts',
+      refresh_button: '.refresh',
     },
     pivotal: {
       label: '<span class="label label-unknown">status</span>',
@@ -63,7 +65,7 @@
     {
       info = pt_info[f];
       statusLabel = config.pivotal.label.replace('unknown' , mapStatusLabelClass(info['status'])).replace('status', info['status']);
-      links += '<a href="' + info['url'] + '" target="_blank">#' + info['id'] + ' ' + statusLabel +'</a><br/>';                 
+      links += '<a href="' + info['url'] + '" target="_blank">#' + info['id'] + '</a> ' + statusLabel + '<br/>';
     }
     return links;
   }
@@ -135,9 +137,18 @@
   $(document).ready(function(){
 
     // add button to story columns
-    var button = '<button class="btn btn-default getStories">get stories</button>';
+    var button = '<button class="btn btn-default getStories">Get stories</button>';
     $(config.selectors.story_column).each(function(){
       $(this).html(button);
+    });
+
+
+    // set up listeners on Refresh Button
+    $(config.selectors.refresh_button).click(function(){
+      var diff_load_status = $(this).parents(config.selectors.project).find(config.selectors.host_column).text();
+      $(this).parents(config.selectors.project).find(config.selectors.story_column).html();
+      $(this).parents(config.selectors.project).find(config.selectors.story_column).html(button);
+      }
     });
 
     // "get stories" button onClick handler
@@ -146,9 +157,10 @@
       e.preventDefault();
       diffs = getProjectDiffs();
       var project = $this_button.parents(config.selectors.project).data('id');
+      var failure_message = 'No stories found.';
+      $this_button.hide(); // do not show button
       if(project in diffs) {
         // great! we found diffs for this project; load the pivotal stories
-        $this_button.hide(); // do not show button
         (function(project) {
         var url = diffs[project];
         // hashes: currentCommit...latestCommit
@@ -163,8 +175,7 @@
 
           var pivotal_ids = getCommitIDs(messages); // extract pivotal ticket IDs
           if(!pivotal_ids) {
-            alert('No associated Pivotal stories found in commit messages.');
-            $this_button.show();
+            $this_button.parents(config.selectors.story_column).text(failure_message);
             return
           };
 
@@ -181,7 +192,7 @@
       })(project);
       }
       else {
-        alert('There seems to be no diffs for ' + project + '. Goship may still be loading the diff, if any. Please try again later.');
+        $this_button.parents(config.selectors.story_column).text(failure_message);
       }
     });
   });

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -44,27 +44,27 @@
 
   function getProjectDiffs(){
 
-      var projectDiffs = [];
+      var project_diffs = [];
 
       $(config.selectors.project).each(function() {
           var project = $(this).attr(config.selectors.project_id);
           var url = $(this).find(config.selectors.github_link).attr('href');
           if (url && url != "undefined"){
-              projectDiffs[project] = url;
+              project_diffs[project] = url;
           }
       });
-      return projectDiffs;
+      return project_diffs;
   }
 
   function getLinkDiv(pt_info) {
     var links = '',
         info,
-        statusLabel;
+        status_label;
     for(f in pt_info)
     {
       info = pt_info[f];
-      statusLabel = config.pivotal.label.replace('unknown' , mapStatusLabelClass(info['status'])).replace('status', info['status']);
-      links += '<a href="' + info['url'] + '" target="_blank">#' + info['id'] + '</a> ' + statusLabel + '<br/>';
+      status_label = config.pivotal.label.replace('unknown' , mapStatusLabelClass(info['status'])).replace('status', info['status']);
+      links += '<a href="' + info['url'] + '" target="_blank">#' + info['id'] + '</a> ' + status_label + '<br/>';
     }
     return links;
   }

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -146,11 +146,14 @@
     $(config.selectors.refresh_button).click(function(){
       // display button once more
       $(this).parents(config.selectors.project).find(config.selectors.story_column).html(button);
+      $(this).parents(config.selectors.project).find('.getStories').click(pivotalButtonOnClickHandler);
     });
 
     // "get stories" button onClick handler
-    $('.getStories').click(function(e){
-      var $this_button = $(this);
+    $('.getStories').click(pivotalButtonOnClickHandler);
+
+    function pivotalButtonOnClickHandler(e) {
+      var $this_button = $(e.currentTarget);
       e.preventDefault();
       diffs = getProjectDiffs();
       var project = $this_button.parents(config.selectors.project).data('id');
@@ -191,6 +194,6 @@
       else {
         $this_button.parents(config.selectors.story_column).text(failure_message);
       }
-    });
+    }
   });
 }(jQuery));

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -144,9 +144,8 @@
 
     // set up listeners on Refresh Button
     $(config.selectors.refresh_button).click(function(){
-      $(this).parents(config.selectors.project).find(config.selectors.story_column).html();
+      // display button once more
       $(this).parents(config.selectors.project).find(config.selectors.story_column).html(button);
-      }
     });
 
     // "get stories" button onClick handler


### PR DESCRIPTION
This PR updates the pivotal plugin such that UI improvements are made.

- instead of Javascript's `alert` functions, we update the table cells right away to inform user if no Pivotal stories are found

- upon  refreshing individual project's statuses, the `Get stories` button reappears for user to recheck the Pivotal stories if need be again.

screenshots

![screen shot 2015-05-22 at 1 27 22 pm](https://cloud.githubusercontent.com/assets/2164346/7764102/597945e8-0086-11e5-8089-35291a0d8061.png)

