### PR TITLE
[update] fix typos in etcdctl section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ There is also a convert.go in tools that can be used to 'bootstrap' etcd.
    etcdctl set /deploy_user 'deployer'
    etcdctl mkdir 'projects'
    etcdctl mkdir 'projects/my-project'
-   etcdctl set /projects/project_name 'My Project'
-   etcdctl set /projects/repo_owner 'github-user'
-   etcdctl set /projects/project_name 'My Project'
+   etcdctl set /projects/my-project/repo_name 'my-project'
+   etcdctl set /projects/my-project/repo_owner 'github-user'
+   etcdctl set /projects/my-project/project_name 'My Project'
 ```
 
    #curl example


### PR DESCRIPTION
This PR fixes some typo in the example setup of ETCD in the README docs.

This is important as the ETCD parser expects the keys in [be in a certain hierarchy](https://github.com/gengo/goship/blob/master/lib/goship.go#L263) (following the current example would result in a error thrown by Goship).