### PR TITLE
open github diff page in new tab

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -64,7 +64,7 @@
     </div>
   </div>
 
-  <div class="hidden" id="host-skeleton"><a class="GitHubCommitURL" href=""></a> <span class="hidden"> (<a class="GitHubDiffURL" href="">diff</a>)</span></div>
+  <div class="hidden" id="host-skeleton"><a class="GitHubCommitURL" href=""></a> <span class="hidden"> (<a class="GitHubDiffURL" href="" target="_blank">diff</a>)</span></div>
 
   <script type="text/javascript">
   GITHUB_TOKEN = "{{.GithubToken}}";


### PR DESCRIPTION
This PR ensures that the `(diff)` link opens the Github commit diff page in a new tab instead of current tab.

![screen shot 2015-07-07 at 1 25 23 pm](https://cloud.githubusercontent.com/assets/2164346/8538713/b08bd9ba-24ab-11e5-99c6-21c6f7c155cd.png)


