### PR TITLE
Always show deploy option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.project
 *.swp
 config.yml
 src/

--- a/goship.go
+++ b/goship.go
@@ -163,7 +163,6 @@ func retrieveCommits(r *http.Request, project goship.Project, deployUser string)
 	// wait for goroutines to finish
 	wg.Wait()
 	for i, e := range project.Environments {
-		e.IsDeployable = e.Deployable()
 
 		project.Environments[i] = e
 		for j, host := range e.Hosts {

--- a/goship_test.go
+++ b/goship_test.go
@@ -139,30 +139,14 @@ func TestGitHubDiffURL(t *testing.T) {
 	}
 }
 
-var deployableTests = []struct {
-	e    goship.Environment
-	want bool
-}{
-	{goship.Environment{LatestGitHubCommit: "abc123", Hosts: []goship.Host{{LatestCommit: "abc456"}}}, true},
-	{goship.Environment{LatestGitHubCommit: "abc456", Hosts: []goship.Host{{LatestCommit: "abc456"}}}, false},
-}
-
-func TestDeployable(t *testing.T) {
-	for _, tt := range deployableTests {
-		if got := tt.e.Deployable(); got != tt.want {
-			t.Errorf("Deployable = %t, want %t", got, tt.want)
-		}
-	}
-}
-
 var wantConfig = goship.Config{
 	Projects: []goship.Project{
 		{Name: "Test Project One", GitHubURL: "https://github.com/test_owner/test_repo_name", RepoName: "test_repo_name", RepoOwner: "test_owner",
 			Environments: []goship.Environment{{Name: "live", Deploy: "/deploy/test_project_one.sh", RepoPath: "/repos/test_repo_name/.git",
-				Hosts: []goship.Host{{URI: "test-project-one.test.com"}}, Branch: "master", IsDeployable: false}}},
+				Hosts: []goship.Host{{URI: "test-project-one.test.com"}}, Branch: "master"}}},
 		{Name: "Test Project Two", GitHubURL: "https://github.com/test_owner/test_repo_name_two", RepoName: "test_repo_name_two", RepoOwner: "test_owner",
 			Environments: []goship.Environment{{Name: "live", Deploy: "/deploy/test_project_two.sh", RepoPath: "/repos/test_repo_name_two/.git",
-				Hosts: []goship.Host{{URI: "test-project-two.test.com"}}, Branch: "master", LatestGitHubCommit: "", IsDeployable: false}}}},
+				Hosts: []goship.Host{{URI: "test-project-two.test.com"}}, Branch: "master", LatestGitHubCommit: ""}}}},
 	DeployUser: "deploy_user",
 	Notify:     "/notify/notify.sh",
 	Pivotal:    &goship.PivotalConfiguration{Project: "111111", Token: "test"}}

--- a/lib/goship.go
+++ b/lib/goship.go
@@ -46,7 +46,6 @@ type Environment struct {
 	Comment            string
 	pivotalCommentURL  string
 	IsLocked           bool
-	IsDeployable       bool
 }
 
 // Column is an interface that demands a RenderHeader and RenderDetails method to be able to generate a table column (with header and body)
@@ -168,17 +167,6 @@ func PostPivotalComment(id string, m string, piv *PivotalConfiguration) (err err
 		log.Printf("ERROR: non-200 Response from Pivotal API: %s %s ", resp.Status, body)
 	}
 	return nil
-}
-
-// Deployable returns true if the latest commit for any of the hosts in an environment
-// differs from the latest commit on GitHub, and false if all of the commits match.
-func (e *Environment) Deployable() bool {
-	for _, h := range e.Hosts {
-		if e.LatestGitHubCommit != h.LatestCommit {
-			return true
-		}
-	}
-	return false
 }
 
 // ShortCommitHash returns a shortened version of the latest commit hash on a host.

--- a/templates/index.html
+++ b/templates/index.html
@@ -117,16 +117,14 @@
                 $host.find('.GitHubDiffURL').attr('href', host.GitHubDiffURL).closest('span.hidden').removeClass('hidden');
               }
             }
-            if (env.IsDeployable) {
-              for (var h = 0; h < env.Hosts.length; h++) {
-                var host = env.Hosts[h];
-                if (host.GitHubDiffURL) {
-                  $deployForm = $env.find('.form-deploy');
-                  $deployForm.removeClass('hidden').find('[name="diffUrl"]').val(host.GitHubDiffURL);
-                  $deployForm.find('[name="from_revision"]').val(host.LatestCommit);
-                  $deployForm.find('[name="to_revision"]').val(env.LatestGitHubCommit);
-                  break;
-                }
+            for (var h = 0; h < env.Hosts.length; h++) {
+              var host = env.Hosts[h];
+              if (host.GitHubDiffURL) {
+                $deployForm = $env.find('.form-deploy');
+                $deployForm.removeClass('hidden').find('[name="diffUrl"]').val(host.GitHubDiffURL);
+                $deployForm.find('[name="from_revision"]').val(host.LatestCommit);
+                $deployForm.find('[name="to_revision"]').val(env.LatestGitHubCommit);
+                break;
               }
             }
             $comment = $env.find(".comment")

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@
                   Loading...
                 </td>
                 <td>
-                  <form class="form-deploy hidden" method="POST" action="/deploy" target="_blank" style="margin-bottom: 0">
+                  <form class="form-deploy" method="POST" action="/deploy" target="_blank" style="margin-bottom: 0">
                     <input type="hidden" name="environment" value="{{$environment.Name}}"/>
                     <input type="hidden" name="project" value="{{$project.Name}}"/>
                     <input type="hidden" name="repo_owner" value="{{$project.RepoOwner}}"/>
@@ -92,7 +92,6 @@
       var $project = $(project),
       projectId = $project.data('id');
       $project.find('.hosts').text('Loading...');
-      $project.find('.form-deploy').addClass('hidden');
       $.ajax({
         type: 'GET',
         url: '/commits/' + projectId,
@@ -119,11 +118,11 @@
             }
             for (var h = 0; h < env.Hosts.length; h++) {
               var host = env.Hosts[h];
-              if (host.GitHubDiffURL) {
                 $deployForm = $env.find('.form-deploy');
-                $deployForm.removeClass('hidden').find('[name="diffUrl"]').val(host.GitHubDiffURL);
                 $deployForm.find('[name="from_revision"]').val(host.LatestCommit);
                 $deployForm.find('[name="to_revision"]').val(env.LatestGitHubCommit);
+              if (host.GitHubDiffURL) {
+                $deployForm.find('[name="diffUrl"]').val(host.GitHubDiffURL);
                 break;
               }
             }


### PR DESCRIPTION
This PR removes the check to show the deploy button only if there is a diff between deployed code and the git repo. 
This check didn't consider other possible conditions needing a re-deploy, even when there is no change in deployed app code base.
Changes in chef code base, base instances change etc, are a few such cases.