### PR TITLE
[#108834896] Workaround for a dead-lock bug in Pivotal Tracker

### DIFF
--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -108,19 +108,15 @@ func PostToPivotal(piv *PivotalConfiguration, env, owner, name, current, latest 
 			continue
 		}
 		m := fmt.Sprintf("Deployed to %s: %s", env, timestamp.Format(layout))
-		go func() {
-			if err := pivClient.AddComment(id, project, m); err != nil {
-				glog.Errorf("failed to post a comment %q to story %d", m, id)
-			}
-		}()
+		if err := pivClient.AddComment(id, project, m); err != nil {
+			glog.Errorf("failed to post a comment %q to story %d", m, id)
+		}
 		if env == "live" {
 			year, week := time.Now().ISOWeek()
 			label := fmt.Sprintf("released_w%d/%d", week, year)
-			go func() {
-				if err := pivClient.AddLabel(id, project, label); err != nil {
-					glog.Errorf("Failed to add a label %q to story %d", label, id)
-				}
-			}()
+			if err := pivClient.AddLabel(id, project, label); err != nil {
+				glog.Errorf("Failed to add a label %q to story %d", label, id)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Avoid concurrent API call because it causes dead-lock in their server-side.
