### PR TITLE
[#109937778] change defautl value of bootstrap flag to true

### DIFF
--- a/tools/deploy/deploy.go
+++ b/tools/deploy/deploy.go
@@ -27,7 +27,7 @@ var (
 	pullOnly         = flag.Bool("o", false, "chef update only (default false)")
 	chefRunlist      = flag.String("r", "", "custom run-list for Chef (default none)")
 	skipUpdate       = flag.Bool("m", false, "skip the chef update (default false)")
-	bootstrap        = flag.Bool("b", false, "bootstrap a server ( default false)")
+	bootstrap        = flag.Bool("b", true, "bootstrap a server ( default true)")
 )
 
 // gitHubPaginationLimit is the default pagination limit for requests to the GitHub API that return multiple items.


### PR DESCRIPTION
We need to find a way to keep remote chef version sync every time we proceed a deploy. I suggest we should use bootstrap as default deploy command. It takes more time to deploy but is much safer.