### PR TITLE
Show story dependencies count and a list of GitHub repositories

### DIFF
--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -8,10 +8,6 @@
       github_link: '.GitHubDiffURL',
       refresh_button: '.refresh',
     },
-    pivotal: {
-      label: '<span class="label label-unknown">status</span>',
-      ticket_id_regexp: /\[#(\d+)\]/g  // we want all matches, not just the first ticket
-    },
     github: {
       url_compare_regexp: /.*\/(.*)\/compare/
     },
@@ -24,8 +20,23 @@
     }
   };
 
+  /**
+   * removeDupesFromArray returns an array without dupes
+   * @param  {Array} arr Any array
+   * @return {Array}     Array without dups
+   */
+  function removeDupesFromArray(arr) {
+    return arr.filter(function(elem, i) {
+      return arr.indexOf(elem) == i;
+    });
+  }
+
+  /**
+   * mapStatusLabelClass returns label class type (as of Twitter Bootstrap 3)
+   * @param  {string} status Pivotal story status
+   * @return {string}        Bootstrap class name
+   */
   function mapStatusLabelClass(status) {
-    // returns label class type (as of Twitter Bootstrap 3)
     switch(status) {
       case 'rejected':
         return 'danger';
@@ -42,29 +53,41 @@
     }
   }
 
+  /**
+   * getProjectDiffs return an Object, project name as the key and github diff URLs
+   * as the value
+   * @return {Object} {project_name: diff_url}
+   */
   function getProjectDiffs() {
-    var project_diffs = [];
+    var diffURLs = {};
 
     $(config.selectors.project).each(function() {
-      var project = $(this).attr(config.selectors.project_id);
-      var url = $(this).find(config.selectors.github_link).attr('href');
-      if (url && url != 'undefined') {
-        project_diffs[project] = url;
+      var $this = $(this);
+      var project = $this.data('id');
+      var url = $this.find(config.selectors.github_link).attr('href');
+
+      if (url) {
+        diffURLs[project] = url;
       }
     });
 
-    return project_diffs;
+    return diffURLs;
   }
 
+  /**
+   * getLinkDiv return an HTML string of story link and status
+   * @param  {Object} pt_info Pivotal story object
+   * @return {String}         HTML string
+   */
   function getLinkDiv(pt_info) {
     var links = [];
-    var info;
-    var status_label;
 
     for (f in pt_info) {
-      info = pt_info[f];
-      status_label = config.pivotal.label.replace('unknown' , mapStatusLabelClass(info['status'])).replace('status', info['status']);
-      links.push('<a href="' + info['url'] + '" target="_blank">#' + info['id'] + '</a> ' + status_label + '<br/>');
+      var story = pt_info[f];
+      var status = '<span class="label label-'+ mapStatusLabelClass(story.status) +'">'+ story.status +'</span>';
+      var dep = '<span class="badge" data-toggle="tooltip" data-placement="top" title="'+ story.dependencies.join(', ') +'">'+ story.dependencies.length +'</span>';
+
+      links.push('<a href="'+ story.url +'" target="_blank">#'+ story.id +'</a>'+ status + dep +'<br/>');
     }
 
     return links.join('');
@@ -72,73 +95,110 @@
 
   function injectPivotalStatus(project_id, pt_info) {
     var project_selector = config.selectors.project + '[' + config.selectors.project_id + '="' + project_id + '"]';
-    $(project_selector).find(config.selectors.story_column).append(getLinkDiv(pt_info));
+    var $project = $(project_selector).find(config.selectors.story_column);
+    $project.append(getLinkDiv(pt_info));
+    $project.find('[data-toggle="tooltip"]').tooltip();
   }
 
-  function getGithubPivotalIDs(github_token, repo, sha1, sha2, callback){
+  /**
+   * getGithubCommits returns Github commits for a given repository
+   * @param  {String}   github_token Github token
+   * @param  {String}   repo         Github repository name
+   * @param  {String}   sha1         Current commit hash
+   * @param  {String}   sha2         Latest commit hash
+   * @param  {Function} callback
+   */
+  function getGithubCommits(github_token, repo, sha1, sha2, callback) {
     $.ajax({
-      url: 'https://api.github.com/repos/gengo/'+ repo + '/compare/' + sha1 + '...' + sha2,
+      url: 'https://api.github.com/repos/gengo/'+ repo +'/compare/'+ sha1 +'...'+ sha2,
       type: 'GET',
-      beforeSend: function(xhr) {
-        xhr.setRequestHeader('Authorization', 'token ' + github_token);
+      headers: {
+        'Authorization': 'token '+ github_token
       },
       success: function(data) {
         callback(data.commits);
       },
-      error: function(data) {
-        console.log(data);
+      error: function(err) {
+        console.error(err);
       }
     });
   }
 
-  function stripBrackets(ticket_id_str) {
-    return parseInt(ticket_id_str.match(/\[#(\d+)\]/)[1], 10); // base 10
+  /**
+   * getPivotalStoryIDs return an array of Pivotal story IDs from array of messages
+   * @param  {Array} msgs Array of string messages
+   * @return {Array}      Array of pivotal IDs
+   */
+  function getPivotalStoryIDs(msgs) {
+    var storyIDs = msgs.map(function(str) {
+      return parseInt(str.match(/\[#(\d+)\]/)[1], 10);
+    });
+
+    return removeDupesFromArray(storyIDs);
   }
 
-  function getCommitIDs(msgs) {
-    // create an object with no prior properties; therefore, all keys in set are the values we want
-    pivotal_ids = Object.create(null);
-    for(msg in msgs) {
-      var message = msgs[msg];
-      var matches = message.match(config.pivotal.ticket_id_regexp);
-
-      if (!matches) {
-        continue;
-      }
-
-      matches.forEach(function(ticket, i, arr) {
-        var id = stripBrackets(ticket);
-        if (id && !(id in pivotal_ids)) {
-          pivotal_ids[id] = true;
-        }
-      });
-    }
-
-    return Object.keys(pivotal_ids); // returning just the keys gives us all unique pivotal IDs
-  }
-
-  function getPivotalInfo(pt_token, story_id, callback){
+  /**
+   * getPivotalStoryInfo return pivotal story data
+   * @param  {string}   pt_token Pivotal token
+   * @param  {number}   story_id Story id
+   * @param  {Function} callback
+   */
+  function getPivotalStoryInfo(pt_token, story_id, callback) {
     $.ajax({
       url: config.urls.pivotal.base + config.urls.pivotal.api + '/stories/' + story_id,
       type: 'GET',
-      beforeSend: function(request) {
-        request.setRequestHeader('X-TrackerToken', pt_token);
+      headers: {
+        'X-TrackerToken': pt_token
       },
       success: function(data) {
-        var info = {
-          'id': story_id
-        };
-        info['status'] = data['current_state'];
-        info['url'] = data['url'];
-        callback(info);
+        getRepoDependencies(pt_token, data.project_id, story_id, function(list) {
+          callback({
+            id: story_id,
+            url: data.url,
+            status: data.current_state,
+            dependencies: list
+          });
+        });
       }
     });
   }
 
-  var diffs = getProjectDiffs();
-  setTimeout(function() {
-    diffs = getProjectDiffs();
-  }, 1000);  // fetch diffs again after 1 sec
+  /**
+   * getRepoDependencies return a list of dependencies for stroy in a project
+   * @param  {String}   pt_token   Pivotal token
+   * @param  {number}   project_id Project ID
+   * @param  {number}   story_id   Story ID
+   * @param  {Function} callback   Returns Pivotal story ID list
+   */
+  function getRepoDependencies(pt_token, project_id, story_id, callback) {
+    $.ajax({
+      url: config.urls.pivotal.base + config.urls.pivotal.api +'/projects/'+ project_id +'/stories/'+ story_id +'/comments',
+      type: 'GET',
+      headers: {
+        'X-TrackerToken': pt_token
+      },
+      success: function(data) {
+        // Find all git commit messages
+        var list = data.filter(function(obj) {
+          return obj.commit_type ? true : false;
+        });
+        // Find repo name from comment body text
+        list = list.map(function(item) {
+          return item.text.split('https://github.com/gengo/')[1].split('/commit/')[0];
+        });
+
+        callback(removeDupesFromArray(list));
+      }
+    });
+  }
+
+  /**
+   * showNoStoriesMessage
+   * @param  {jQuery} $target jQuery button object
+   */
+  function showNoStoriesMessage($target) {
+    $target.closest(config.selectors.story_column).text('No stories found.');
+  }
 
   $(document).ready(function() {
     // add button to story columns
@@ -147,25 +207,17 @@
       $(this).html(button);
     });
 
-    // set up listeners on Refresh Button
+    // When reset button clecked add Get stories button
     $(config.selectors.refresh_button).click(function() {
-      // display button once more
-      var $p = $(this).parents(config.selectors.project);
-      $p.find(config.selectors.story_column).html(button);
-      $p.find('.getStories').click(pivotalButtonOnClickHandler);
+      $(this).closest(config.selectors.project).find(config.selectors.story_column).html(button);
     });
 
-    // "get stories" button onClick handler
-    $('.getStories').click(pivotalButtonOnClickHandler);
-
-    function pivotalButtonOnClickHandler(e) {
+    $('.project').on('click', '.getStories', function(e) {
       e.preventDefault();
 
       var $this_button = $(e.currentTarget);
       var project = $this_button.parents(config.selectors.project).data('id');
-      var failure_message = 'No stories found.';
-
-      diffs = getProjectDiffs();
+      var diffs = getProjectDiffs();
 
       $this_button.hide(); // do not show button
 
@@ -176,18 +228,18 @@
         (function(project) {
           var url = diffs[project];
           // hashes: currentCommit...latestCommit
-          var hashes = (url.substr(url.lastIndexOf('/') + 1)).split('...');
-          var proj_name = url.match(config.github.url_compare_regexp)[1];
+          var commitHashes = (url.substr(url.lastIndexOf('/') + 1)).split('...');
+          var repositoryName = url.match(config.github.url_compare_regexp)[1];
 
-          getGithubPivotalIDs(GITHUB_TOKEN, proj_name, hashes[0], hashes[1], function(commits) {
-            var messages = [];
-            for (commit in commits) {
-              messages.push(commits[commit]['commit']['message']); // get all github commit messages
-            }
-
-            var pivotal_ids = getCommitIDs(messages); // extract pivotal ticket IDs
+          getGithubCommits(GITHUB_TOKEN, repositoryName, commitHashes[0], commitHashes[1], function(commits) {
+            // Array of comitt messages
+            var messages = commits.map(function(obj) {
+              return obj.commit.message;
+            });
+            // Array of pivotal story IDs
+            var pivotal_ids = getPivotalStoryIDs(messages);
             if (!pivotal_ids) {
-              $this_button.parents(config.selectors.story_column).text(failure_message);
+              showNoStoriesMessage($this_button);
               return;
             };
 
@@ -197,7 +249,7 @@
             for (pt_id in pivotal_ids) {
               var id = pivotal_ids[pt_id];
 
-              getPivotalInfo(PIVOTAL_TOKEN, id, function(info) {
+              getPivotalStoryInfo(PIVOTAL_TOKEN, id, function(info) {
                 display_message[id] = info;
                 injectPivotalStatus(project, display_message);
               });
@@ -206,8 +258,9 @@
         })(project);
       }
       else {
-        $this_button.parents(config.selectors.story_column).text(failure_message);
+        showNoStoriesMessage($this_button);
       }
-    }
+    });
+
   });
 }(jQuery));

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -108,13 +108,12 @@
    * getGithubCommits returns Github commits for a given repository
    * @param  {String}   github_token Github token
    * @param  {String}   repo         Github repository name
-   * @param  {String}   sha1         Current commit hash
-   * @param  {String}   sha2         Latest commit hash
+   * @param  {String}   commitHashes Current and Latest commit hash
    * @param  {Function} callback
    */
-  function getGithubCommits(github_token, repo, sha1, sha2, callback) {
+  function getGithubCommits(github_token, repo, commitHashes, callback) {
     $.ajax({
-      url: 'https://api.github.com/repos/gengo/'+ repo +'/compare/'+ sha1 +'...'+ sha2,
+      url: 'https://api.github.com/repos/gengo/'+ repo +'/compare/'+ commitHashes[0] +'...'+ commitHashes[1],
       type: 'GET',
       headers: {
         'Authorization': 'token '+ github_token
@@ -235,7 +234,7 @@
           var commitHashes = (url.substr(url.lastIndexOf('/') + 1)).split('...');
           var repositoryName = url.match(config.github.url_compare_regexp)[1];
 
-          getGithubCommits(GITHUB_TOKEN, repositoryName, commitHashes[0], commitHashes[1], function(commits) {
+          getGithubCommits(GITHUB_TOKEN, repositoryName, commitHashes, function(commits) {
             // Array of comitt messages
             var messages = commits.map(function(obj) {
               return obj.commit.message;

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -65,12 +65,12 @@
    * getGithubCommits returns Github commits for a given repository
    * @param  {String}   github_token Github token
    * @param  {String}   repo         Github repository name
-   * @param  {String}   commitHashes Current and Latest commit hash
+   * @param  {String}   commitHashe  Current and Latest commit hash
    * @param  {Function} callback
    */
-  function getGithubCommits(github_token, repo, commitHashes, callback) {
+  function getGithubCommits(github_token, repo, commitHashe, callback) {
     $.ajax({
-      url: 'https://api.github.com/repos/gengo/'+ repo +'/compare/'+ commitHashes[0] +'...'+ commitHashes[1],
+      url: 'https://api.github.com/repos/gengo/'+ repo +'/compare/'+ commitHashes,
       type: 'GET',
       headers: {
         'Authorization': 'token '+ github_token
@@ -171,7 +171,7 @@
 
     $('.project[data-id="'+ project +'"]')
       .find('.story')
-        .append(html.join(''))
+        .html(html)
       .find('[data-toggle="popover"]')
         .popover({
           html: true,
@@ -214,17 +214,17 @@
 
         var url = diffs[project];
         // hashes: currentCommit...latestCommit
-        var commitHashes = (url.substr(url.lastIndexOf('/') + 1)).split('...');
+        var commitHashe = url.substr(url.lastIndexOf('/') + 1);
         var repositoryName = url.match(/.*\/(.*)\/compare/)[1];
 
-        getGithubCommits(GITHUB_TOKEN, repositoryName, commitHashes, function(commits) {
+        getGithubCommits(GITHUB_TOKEN, repositoryName, commitHashe, function(commits) {
           // Array of comitt messages
           var messages = commits.map(function(obj) {
             return obj.commit.message;
           });
           // Array of pivotal story IDs
           var pivotal_ids = getPivotalStoryIDs(messages);
-          if (!pivotal_ids) {
+          if (pivotal_ids.length === 0) {
             showNoStoriesMessage($this_button);
             return;
           };
@@ -234,7 +234,7 @@
             getPivotalStoryInfo(PIVOTAL_TOKEN, pivotal_ids[i], function(info) {
               storyList.push(info);
 
-              if (storyList.length === pivotal_ids.length) {
+              if (storyList.length === imax) {
                 $this_button.siblings('.loading').hide();
                 onGetPivotalStoryInfoComplete(project, storyList);
               }

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -85,7 +85,7 @@
     for (f in pt_info) {
       var story = pt_info[f];
       var status = '<span class="label label-'+ mapStatusLabelClass(story.status) +'">'+ story.status +'</span>';
-      var dep = '<span class="badge" data-toggle="tooltip" data-placement="top" title="'+ story.dependencies.join(', ') +'">'+ story.dependencies.length +'</span>';
+      var dep = '<span class="badge" data-toggle="popover" data-content="<li>'+ info.dependencies.join('</li><li>') +'</li>">'+ story.dependencies.length +'</span>';
 
       links.push('<a href="'+ story.url +'" target="_blank">#'+ story.id +'</a>'+ status + dep +'<br/>');
     }
@@ -97,7 +97,11 @@
     var project_selector = config.selectors.project + '[' + config.selectors.project_id + '="' + project_id + '"]';
     var $project = $(project_selector).find(config.selectors.story_column);
     $project.append(getLinkDiv(pt_info));
-    $project.find('[data-toggle="tooltip"]').tooltip();
+    $project.find('[data-toggle="popover"]').popover({
+      html: true,
+      trigger: 'hover',
+      placement: 'top'
+    });
   }
 
   /**

--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -85,7 +85,7 @@
     for (f in pt_info) {
       var story = pt_info[f];
       var status = '<span class="label label-'+ mapStatusLabelClass(story.status) +'">'+ story.status +'</span>';
-      var dep = '<span class="badge" data-toggle="popover" data-content="<li>'+ info.dependencies.join('</li><li>') +'</li>">'+ story.dependencies.length +'</span>';
+      var dep = '<span class="badge" data-toggle="popover" data-content="<li>'+ story.dependencies.join('</li><li>') +'</li>">'+ story.dependencies.length +'</span>';
 
       links.push('<a href="'+ story.url +'" target="_blank">#'+ story.id +'</a>'+ status + dep +'<br/>');
     }
@@ -184,7 +184,7 @@
       success: function(data) {
         // Find all git commit messages
         var list = data.filter(function(obj) {
-          return obj.commit_type ? true : false;
+          return obj.commit_type;
         });
         // Find repo name from comment body text
         list = list.map(function(item) {
@@ -211,7 +211,7 @@
       $(this).html(button);
     });
 
-    // When reset button clecked add Get stories button
+    // When reset button clicked add Get stories button
     $(config.selectors.refresh_button).click(function() {
       $(this).closest(config.selectors.project).find(config.selectors.story_column).html(button);
     });


### PR DESCRIPTION
![screen shot 2016-02-04 at 5 16 17 pm](https://cloud.githubusercontent.com/assets/228359/12809506/17d24c18-cb63-11e5-93df-bf569e6dc02b.png)

It was very hard to identify before deploying if there are any other repository dependencies. In this PR I check pivotal story activity to check if there are any GitHub activity like commits and grab repository names from there. So, if the developer doesn't properly add pivotal story ID to his commits then this functionality won't work.

Also some code refactoring.