### PR TITLE
[fix] bind console.error function to console itself

### DIFF
--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -9,7 +9,7 @@
   };
 
   // register common error handler on Ajax errors / failures
-  $(document).ajaxError(console.error);
+  $(document).ajaxError(console.error.bind(console));
 
   /**
    * removeDupesFromArray returns an array without dupes


### PR DESCRIPTION
related PR: https://github.com/gengo/goship/pull/186

This PR fixes the issue when console.error is passed as a function to call in `ajaxError()`.
We need to bind console function to console itself.