### PR TITLE
[#114274829] handle when pivotal story not found

### DIFF
--- a/static/js/pivotal.js
+++ b/static/js/pivotal.js
@@ -154,6 +154,10 @@
             dependencies: list
           });
         });
+      },
+      error: function(err) {
+        // e.g., no pivotal story found
+        callback(undefined);
       }
     });
   }
@@ -323,9 +327,10 @@
           var storyList = [];
           for (var i = 0, imax = pivotal_ids.length; i < imax; i++) {
             getPivotalStoryInfo(PIVOTAL_TOKEN, pivotal_ids[i], function(info) {
-              storyList.push(info);
-
-              if (storyList.length === imax) {
+              // if getPivtoalStoryInfo is unsuccessful, info is undefined
+              !!info && storyList.push(info);
+              // we have cycled through all possible pivotal stories (some unsuccessful perhaps)
+              if (i === imax) {
                 $this_button.siblings('.loading').hide();
                 onGetPivotalStoryInfoComplete(project, storyList);
               }


### PR DESCRIPTION
story: https://www.pivotaltracker.com/story/show/114274829

This PR updates the Pivotal javascript such that we can gracefully handle the situation when Pivotal API returns an error (e.g., story not found for pivotal ticket ID)

The earlier PR(https://github.com/gengo/goship/pull/187) ensures that the unsuccessful request on Pivotal API would be logged as well.

Else, what is currently happening now, is that the UI continues to show `Loading...` and does not display any story statuses for the successful / found pivotal stories.